### PR TITLE
Refactor: Add strand attributes

### DIFF
--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -30,14 +30,14 @@ class TestChildrenTwine(BaseTestCase):
         """
         twine_file = self.path + "twines/valid_children_twine.json"
         twine = Twine(source=twine_file)
-        self.assertEqual(len(twine._raw["children"]), 1)
+        self.assertEqual(len(twine._children), 1)
 
     def test_empty_children(self):
         """ Ensures that a twine file will validate with an empty list object as children
         """
         twine_file = self.path + "twines/valid_empty_children_twine.json"
         twine = Twine(source=twine_file)
-        self.assertEqual(len(twine._raw["children"]), 0)
+        self.assertEqual(len(twine._children), 0)
 
 
 class TestChildrenValidation(BaseTestCase):

--- a/twined/twine.py
+++ b/twined/twine.py
@@ -1,4 +1,3 @@
-import functools
 import json as jsonlib
 import logging
 import os
@@ -56,6 +55,8 @@ class Twine:
         """
         for name, strand in self._load_twine(**kwargs).items():
             setattr(self, '_' + name, strand)
+
+        self._available_strands = tuple(trim_suffix(name, "_schema") for name in vars(self))
 
     def _load_twine(self, source=None):
         """ Load twine from a *.json filename, file-like or a json string and validates twine contents
@@ -171,11 +172,11 @@ class Twine:
 
         return data
 
-    @functools.cached_property
+    @property
     def available_strands(self):
         """ Tuple of strand names that are found in this twine
         """
-        return tuple(trim_suffix(name, "_schema") for name in vars(self))
+        return self._available_strands
 
     def validate_children(self, **kwargs):
         """ Validates that the children values, passed as either a file or a json string, are correct


### PR DESCRIPTION
## Summary
* Make strands private attributes of `Twine` rather than storing them in the `_raw` dictionary
* Remove setter method for `available_strands` property as properties are read-only by default

## Notes
* I didn't make the strands properties as it's quite difficult to dynamically create properties. They're private, however, which should discourage meddling with them
* Let me know if I'm wrong about the setter method

## Links
* Issue #42 