### PR TITLE
Fix child validation and missing strand data validation

### DIFF
--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -37,13 +37,13 @@ class TestChildrenTwine(BaseTestCase):
                 "children": [{"key": "gis", "purpose": "The purpose.", "notes": "Some notes.", "filters": "tags:gis"}]
             }
         """
-        self.assertEqual(len(Twine(source=source)._children), 1)
+        self.assertEqual(len(Twine(source=source).children), 1)
 
     def test_empty_children(self):
         """ Ensures that a twine file will validate with an empty list object as children
         """
         twine = Twine(source="""{"children": []}""")
-        self.assertEqual(len(twine._children), 0)
+        self.assertEqual(len(twine.children), 0)
 
 
 class TestChildrenValidation(BaseTestCase):

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -58,7 +58,15 @@ class TestChildrenValidation(BaseTestCase):
 
     VALID_CHILD_VALUE = """
         [
-            {"key": "gis", "id": "some-id", "uri_env_name": "NAME_OF_SOME_ENV_VAR_THAT_CONTAINS_A_URI"}
+            {
+                "key": "gis",
+                "id": "some-id",
+                "backend": {
+                    "name": "GCPPubSubBackend",
+                    "project_name": "my-project",
+                    "credentials_filename": "hello.json"
+                }
+            }
         ]
     """
 
@@ -101,7 +109,11 @@ class TestChildrenValidation(BaseTestCase):
                 {
                     "key": "gis",
                     "id": "some-id",
-                    "uri_env_name": "SOME_ENV_VAR_NAME",
+                    "backend": {
+                        "name": "GCPPubSubBackend",
+                        "project_name": "my-project",
+                        "credentials_filename": "hello.json"
+                    },
                     "some_extra_property": "should not be a problem if present"
                 }
             ]

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -87,6 +87,13 @@ class TestChildrenValidation(BaseTestCase):
         with self.assertRaises(exceptions.InvalidValuesContents):
             Twine().validate_children(source=self.VALID_CHILD_VALUE)
 
+    def test_backend_cannot_be_empty(self):
+        """ Test that the backend field of a child cannot be empty. """
+        single_child_missing_backend = """[{"key": "gis", "id": "some-id", "backend": {}}]"""
+
+        with self.assertRaises(exceptions.InvalidValuesContents):
+            Twine().validate_children(source=single_child_missing_backend)
+
     def test_extra_key_validation_on_empty_twine(self):
         """ Test that children with extra data will not raise a validation error on an empty twine.
         """

--- a/twined/schema/children_schema.json
+++ b/twined/schema/children_schema.json
@@ -20,8 +20,9 @@
                         "title": "GCP Pub/Sub",
                         "properties": {
                             "name": {
-                                "description": "Type of backend (in this case, it should be GCPPubSub",
-                                "type": "string"
+                                "description": "Type of backend (in this case, it can only be GCPPubSub)",
+                                "type": "string",
+                                "pattern": "^(GCPPubSubBackend)$"
                             },
                             "project_name": {
                                 "description": "Name of the Google Cloud Platform (GCP) project the child exists in.",

--- a/twined/schema/children_schema.json
+++ b/twined/schema/children_schema.json
@@ -20,7 +20,7 @@
                         "title": "GCP Pub/Sub",
                         "properties": {
                             "name": {
-                                "description": "Type of backend (in this case, it can only be GCPPubSub)",
+                                "description": "Type of backend (in this case, it can only be GCPPubSubBackend)",
                                 "type": "string",
                                 "pattern": "^(GCPPubSubBackend)$"
                             },

--- a/twined/schema/children_schema.json
+++ b/twined/schema/children_schema.json
@@ -32,7 +32,8 @@
                                 "description": "Absolute path to Google Cloud Platform credentials JSON file.",
                                 "type": "string"
                             }
-                        }
+                        },
+                        "required": ["name", "project_name", "credentials_filename"]
                     }
                 ]
             }

--- a/twined/schema/children_schema.json
+++ b/twined/schema/children_schema.json
@@ -11,12 +11,11 @@
                 "description": "The universally unique ID of the running child twin",
                 "type": "string"
             },
-            "uri_env_name": {
-                "description": "Name of the environment variable containing the URI of the twin (which may contain credentials)",
-                "type": "string",
-                "pattern": "^[A-Z]+(?:_[A-Z]+)*$"
+            "gcp_project_name": {
+                "description": "Name of the Google Cloud Platform (GCP) project the child exists in.",
+                "type": "string"
             }
         },
-        "required": ["key", "id", "uri_env_name"]
+        "required": ["key", "id", "gcp_project_name"]
     }
 }

--- a/twined/schema/children_schema.json
+++ b/twined/schema/children_schema.json
@@ -11,11 +11,31 @@
                 "description": "The universally unique ID (UUID) of the running child twin",
                 "type": "string"
             },
-            "gcp_project_name": {
-                "description": "Name of the Google Cloud Platform (GCP) project the child exists in.",
-                "type": "string"
+            "backend": {
+                "description": "The backend running the child.",
+                "type": "object",
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "title": "GCP Pub/Sub",
+                        "properties": {
+                            "name": {
+                                "description": "Type of backend (in this case, it should be GCPPubSub",
+                                "type": "string"
+                            },
+                            "project_name": {
+                                "description": "Name of the Google Cloud Platform (GCP) project the child exists in.",
+                                "type": "string"
+                            },
+                            "credentials_filename": {
+                                "description": "Absolute path to Google Cloud Platform credentials JSON file.",
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
             }
         },
-        "required": ["key", "id", "gcp_project_name"]
+        "required": ["key", "id", "backend"]
     }
 }

--- a/twined/schema/children_schema.json
+++ b/twined/schema/children_schema.json
@@ -8,7 +8,7 @@
                 "type": "string"
             },
             "id": {
-                "description": "The universally unique ID of the running child twin",
+                "description": "The universally unique ID (UUID) of the running child twin",
                 "type": "string"
             },
             "gcp_project_name": {

--- a/twined/twine.py
+++ b/twined/twine.py
@@ -178,11 +178,11 @@ class Twine:
         """
         return self._available_strands
 
-    def validate_children(self, source):
+    def validate_children(self, source, **kwargs):
         """ Validates that the children values, passed as either a file or a json string, are correct
         """
         # TODO cache this loaded data keyed on a hashed version of kwargs
-        children = self._load_json("children", source)
+        children = self._load_json("children", source, **kwargs)
         self._validate_against_schema("children", children)
 
         strand = getattr(self, "children", [])

--- a/twined/twine.py
+++ b/twined/twine.py
@@ -54,7 +54,7 @@ class Twine:
         """ Constructor for the twine class
         """
         for name, strand in self._load_twine(**kwargs).items():
-            setattr(self, "_" + name, strand)
+            setattr(self, name, strand)
 
         self._available_strands = tuple(trim_suffix(name, "_schema") for name in vars(self))
 
@@ -119,7 +119,7 @@ class Twine:
         else:
             if strand not in SCHEMA_STRANDS:
                 raise exceptions.UnknownStrand(f"Unknown strand {strand}. Try one of {ALL_STRANDS}.")
-            schema_key = "_" + strand + "_schema"
+            schema_key = strand + "_schema"
             try:
                 schema = getattr(self, schema_key)
             except AttributeError:
@@ -178,14 +178,14 @@ class Twine:
         """
         return self._available_strands
 
-    def validate_children(self, **kwargs):
+    def validate_children(self, source):
         """ Validates that the children values, passed as either a file or a json string, are correct
         """
         # TODO cache this loaded data keyed on a hashed version of kwargs
-        children = self._load_json("children", **kwargs)
+        children = self._load_json("children", source)
         self._validate_against_schema("children", children)
 
-        strand = getattr(self, "_children", [])
+        strand = getattr(self, "children", [])
 
         # Loop the children and accumulate values so we have an O(1) check
         children_keys = {}
@@ -249,7 +249,7 @@ class Twine:
 
         # Loop through the required credentials to check for presence of each
         credentials = {}
-        for credential in getattr(self, "_credentials", []):
+        for credential in getattr(self, "credentials", []):
             name = credential["name"]
             default = credential.get("default", None)
             credentials[name] = os.environ.get(name, default)


### PR DESCRIPTION
## Contents

### Minor fixes and improvements

- [x] Fix child validation by adding missing argument `source`
- [x] Fix missing strand data validation by making strand attributes public (this removes the disparity between the attributes being private but the related names being used not including a leading underscore)
- [x] Replace  `uri_env_name` field with `backend` field in children schema