### PR TITLE
Feature: Require environment variable for children credentials

### DIFF
--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -64,7 +64,7 @@ class TestChildrenValidation(BaseTestCase):
                 "backend": {
                     "name": "GCPPubSubBackend",
                     "project_name": "my-project",
-                    "credentials_filename": "hello.json"
+                    "credentials_environment_variable": "GCP_SERVICE_ACCOUNT"
                 }
             }
         ]
@@ -119,7 +119,7 @@ class TestChildrenValidation(BaseTestCase):
                     "backend": {
                         "name": "GCPPubSubBackend",
                         "project_name": "my-project",
-                        "credentials_filename": "hello.json"
+                        "credentials_environment_variable": "GCP_SERVICE_ACCOUNT"
                     },
                     "some_extra_property": "should not be a problem if present"
                 }

--- a/twined/schema/children_schema.json
+++ b/twined/schema/children_schema.json
@@ -28,12 +28,12 @@
                                 "description": "Name of the Google Cloud Platform (GCP) project the child exists in.",
                                 "type": "string"
                             },
-                            "credentials_filename": {
-                                "description": "Absolute path to Google Cloud Platform credentials JSON file.",
+                            "credentials_environment_variable": {
+                                "description": "Name of environment variable containing either the absolute path to a Google Cloud Platform credentials JSON file or the JSON itself as a string.",
                                 "type": "string"
                             }
                         },
-                        "required": ["name", "project_name", "credentials_filename"]
+                        "required": ["name", "project_name", "credentials_environment_variable"]
                     }
                 ]
             }


### PR DESCRIPTION
### Breaking change
- [x] Require a `credentials_environment_variable` field in children backend schema instead of `credentials_filename`. This variable can be a path to a credentials file or the credentials file as a string

## Quality Checklist

- [x] New features are fully tested (No matter how much Coverage Karma you have)