### PR TITLE
OPS: Allow skipping of CI tests based on commit comment

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -19,6 +19,7 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '#skip_ci_tests')"
     env:
       USING_COVERAGE: '3.8'
     strategy:


### PR DESCRIPTION
## Contents

### New Features

- [x] Allow skipping of CI tests if `#skip_ci_tests` is in the commit body - the use case is to reduce unnecessary computation when knowing the tests will fail for a commit but still wanting to commit.
