### PR TITLE
Simplify twine and manifest schemas

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
           - '^hotfix/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
           - '^refactor/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
           - '^review/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
-          - '^release/(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+          - '^enhancement/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
 
   - repo: https://github.com/octue/pre-commit-hooks
     rev: 0.5.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("LICENSE") as f:
 
 setup(
     name="twined",
-    version="0.1.2",
+    version="0.1.3",
     py_modules=[],
     install_requires=["jsonschema ~= 3.2.0", "python-dotenv"],
     url="https://www.github.com/octue/twined",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("LICENSE") as f:
 
 setup(
     name="twined",
-    version="0.1.3",
+    version="0.2.0",
     py_modules=[],
     install_requires=["jsonschema ~= 3.2.0", "python-dotenv"],
     url="https://www.github.com/octue/twined",

--- a/tests/data/apps/empty_app/twine.json
+++ b/tests/data/apps/empty_app/twine.json
@@ -12,7 +12,7 @@
 	"credentials": [
 	],
 	"input_manifest": {
-		"datasets": []
+		"datasets": {}
 	},
 	"input_values_schema": {
 		"$schema": "http://json-schema.org/2019-09/schema#",
@@ -23,7 +23,7 @@
 		}
 	},
 	"output_manifest": {
-		"datasets": []
+		"datasets": {}
 	},
 	"output_values_schema": {
 		"title": "Output Values",

--- a/tests/data/apps/example_app/twine.json
+++ b/tests/data/apps/example_app/twine.json
@@ -32,16 +32,14 @@
 		}
 	],
 	"input_manifest": {
-		"datasets": [
-			{
-				"key": "met_mast_data",
+		"datasets": {
+			"met_mast_data": {
 				"purpose": "A dataset containing meteorological mast data"
 			},
-			{
-				"key": "scada_data",
+			"scada_data": {
 				"purpose": "A dataset containing scada data"
 			}
-		]
+		}
 	},
 	"input_values_schema": {
 		"$schema": "http://json-schema.org/2019-09/schema#",
@@ -57,12 +55,11 @@
 		}
 	},
 	"output_manifest": {
-		"datasets": [
-			{
-				"key": "production_data",
+		"datasets": {
+			"production_data": {
 				"purpose": "A dataset containing production data"
 			}
-		]
+		}
 	},
 	"output_values_schema": {
 		"title": "Output Values",

--- a/tests/data/apps/simple_app/twine.json
+++ b/tests/data/apps/simple_app/twine.json
@@ -68,6 +68,6 @@
 		}
 	},
 	"output_manifest": {
-		"datasets": []
+		"datasets": {}
 	}
 }

--- a/tests/test_manifest_strands.py
+++ b/tests/test_manifest_strands.py
@@ -13,32 +13,28 @@ class TestManifestStrands(BaseTestCase):
     VALID_MANIFEST_STRAND = """
         {
             "configuration_manifest": {
-                "datasets": [
-                    {
-                        "key": "configuration_files_data",
+                "datasets": {
+                    "configuration_files_data": {
                         "purpose": "A dataset containing files used in configuration"
                     }
-                ]
+                }
             },
             "input_manifest": {
-                "datasets": [
-                    {
-                        "key": "met_mast_data",
+                "datasets": {
+                    "met_mast_data": {
                         "purpose": "A dataset containing meteorological mast data"
                     },
-                    {
-                        "key": "scada_data",
+                    "scada_data": {
                         "purpose": "A dataset containing scada data"
                     }
-                ]
+                }
             },
             "output_manifest": {
-                "datasets": [
-                    {
-                        "key": "output_files_data",
+                "datasets": {
+                    "output_files_data": {
                         "purpose": "A dataset containing output results"
                     }
-                ]
+                }
             }
         }
     """
@@ -46,9 +42,8 @@ class TestManifestStrands(BaseTestCase):
     TWINE_WITH_INPUT_MANIFEST_WITH_TAG_TEMPLATE = """
         {
             "input_manifest": {
-                "datasets": [
-                    {
-                        "key": "met_mast_data",
+                "datasets": {
+                    "met_mast_data": {
                         "purpose": "A dataset containing meteorological mast data",
                         "file_tags_template": {
                             "type": "object",
@@ -74,7 +69,7 @@ class TestManifestStrands(BaseTestCase):
                             ]
                         }
                     }
-                ]
+                }
             }
         }
     """
@@ -430,15 +425,14 @@ class TestManifestStrands(BaseTestCase):
             """
             {
                 "input_manifest": {
-                    "datasets": [
-                        {
-                            "key": "met_mast_data",
+                    "datasets": {
+                        "met_mast_data": {
                             "purpose": "A dataset containing meteorological mast data",
                             "file_tags_template": {
                                 "$ref": "%s"
                             }
                         }
-                    ]
+                    }
                 }
             }
             """
@@ -480,9 +474,8 @@ class TestManifestStrands(BaseTestCase):
         twine_with_input_manifest_with_required_tags_for_multiple_datasets = """
             {
                 "input_manifest": {
-                    "datasets": [
-                        {
-                            "key": "first_dataset",
+                    "datasets": {
+                        "first_dataset": {
                             "purpose": "A dataset containing meteorological mast data",
                             "file_tags_template": {
                                 "type": "object",
@@ -496,8 +489,7 @@ class TestManifestStrands(BaseTestCase):
                                 }
                             }
                         },
-                        {
-                            "key": "second_dataset",
+                        "second_dataset": {
                             "file_tags_template": {
                                 "type": "object",
                                 "properties": {
@@ -510,7 +502,7 @@ class TestManifestStrands(BaseTestCase):
                                 }
                             }
                         }
-                    ]
+                    }
                 }
             }
         """

--- a/tests/test_manifest_strands.py
+++ b/tests/test_manifest_strands.py
@@ -1,6 +1,5 @@
 import copy
 import os
-import unittest
 from unittest.mock import patch
 from jsonschema.validators import RefResolver
 
@@ -598,6 +597,24 @@ class TestManifestStrands(BaseTestCase):
         with self.assertRaises(KeyError):
             twine.validate_input_manifest(source=input_manifest)
 
+    def test_error_raised_if_datasets_not_given_as_dictionary(self):
+        """Test that an error is raised if datasets are not given as a dictionary."""
+        input_manifest = """
+            {
+                "id": "8ead7669-8162-4f64-8cd5-4abe92509e17",
+                "datasets": [
+                    {
+                        "id": "7ead7669-8162-4f64-8cd5-4abe92509e19",
+                        "name": "met_mast_data",
+                        "tags": {},
+                        "labels": [],
+                        "files": []
+                    }
+                ]
+            }
+        """
 
-if __name__ == "__main__":
-    unittest.main()
+        twine = Twine(source=self.TWINE_WITH_INPUT_MANIFEST_WITH_TAG_TEMPLATE)
+
+        with self.assertRaises(exceptions.InvalidManifestContents):
+            twine.validate_input_manifest(source=input_manifest)

--- a/tests/test_manifest_strands.py
+++ b/tests/test_manifest_strands.py
@@ -83,8 +83,8 @@ class TestManifestStrands(BaseTestCase):
     INPUT_MANIFEST_WITH_CORRECT_FILE_TAGS = """
         {
             "id": "8ead7669-8162-4f64-8cd5-4abe92509e17",
-            "datasets": [
-                {
+            "datasets": {
+                "met_mast_data": {
                     "id": "7ead7669-8162-4f64-8cd5-4abe92509e17",
                     "name": "met_mast_data",
                     "tags": {},
@@ -122,7 +122,7 @@ class TestManifestStrands(BaseTestCase):
                         }
                     ]
                 }
-            ]
+            }
         }
     """
 
@@ -145,8 +145,8 @@ class TestManifestStrands(BaseTestCase):
         valid_configuration_manifest = """
             {
                 "id": "3ead7669-8162-4f64-8cd5-4abe92509e17",
-                "datasets": [
-                    {
+                "datasets": {
+                    "configuration_files_data": {
                         "id": "34ad7669-8162-4f64-8cd5-4abe92509e17",
                         "name": "configuration_files_data",
                         "tags": {},
@@ -182,15 +182,15 @@ class TestManifestStrands(BaseTestCase):
                             }
                         ]
                     }
-                ]
+                }
             }
         """
 
         valid_input_manifest = """
             {
                 "id": "8ead7669-8162-4f64-8cd5-4abe92509e17",
-                "datasets": [
-                    {
+                "datasets": {
+                    "met_mast_data": {
                         "id": "7ead7669-8162-4f64-8cd5-4abe92509e17",
                         "name": "met_mast_data",
                         "tags": {},
@@ -226,15 +226,15 @@ class TestManifestStrands(BaseTestCase):
                             }
                         ]
                     }
-                ]
+                }
             }
         """
 
         valid_output_manifest = """
             {
                 "id": "2ead7669-8162-4f64-8cd5-4abe92509e17",
-                "datasets": [
-                    {
+                "datasets": {
+                    "output_files_data": {
                         "id": "1ead7669-8162-4f64-8cd5-4abe92509e17",
                         "name": "output_files_data",
                         "tags": {},
@@ -270,7 +270,7 @@ class TestManifestStrands(BaseTestCase):
                             }
                         ]
                     }
-                ]
+                }
             }
         """
 
@@ -348,8 +348,8 @@ class TestManifestStrands(BaseTestCase):
         input_manifest = """
             {
                 "id": "8ead7669-8162-4f64-8cd5-4abe92509e17",
-                "datasets": [
-                    {
+                "datasets": {
+                    "met_mast_data": {
                         "id": "7ead7669-8162-4f64-8cd5-4abe92509e17",
                         "name": "met_mast_data",
                         "tags": {},
@@ -367,7 +367,7 @@ class TestManifestStrands(BaseTestCase):
                             }
                         ]
                     }
-                ]
+                }
             }
         """
 
@@ -383,8 +383,8 @@ class TestManifestStrands(BaseTestCase):
         input_manifest = """
             {
                 "id": "8ead7669-8162-4f64-8cd5-4abe92509e17",
-                "datasets": [
-                    {
+                "datasets": {
+                    "met_mast_data": {
                         "id": "7ead7669-8162-4f64-8cd5-4abe92509e17",
                         "name": "met_mast_data",
                         "tags": {},
@@ -402,7 +402,7 @@ class TestManifestStrands(BaseTestCase):
                             }
                         ]
                     }
-                ]
+                }
             }
         """
 
@@ -519,8 +519,8 @@ class TestManifestStrands(BaseTestCase):
         input_manifest = """
             {
                 "id": "8ead7669-8162-4f64-8cd5-4abe92509e17",
-                "datasets": [
-                    {
+                "datasets": {
+                    "first_dataset": {
                         "id": "7ead7669-8162-4f64-8cd5-4abe92509e19",
                         "name": "first_dataset",
                         "tags": {},
@@ -541,7 +541,7 @@ class TestManifestStrands(BaseTestCase):
                             }
                         ]
                     },
-                    {
+                    "second_dataset": {
                         "id": "7ead7669-8162-4f64-8cd5-4abe92509e18",
                         "name": "second_dataset",
                         "tags": {},
@@ -562,7 +562,7 @@ class TestManifestStrands(BaseTestCase):
                             }
                         ]
                     }
-                ]
+                }
             }
         """
 
@@ -574,28 +574,28 @@ class TestManifestStrands(BaseTestCase):
         input_manifest = """
             {
                 "id": "8ead7669-8162-4f64-8cd5-4abe92509e17",
-                "datasets": [
-                    {
+                "datasets": {
+                    "met_mast_data": {
                         "id": "7ead7669-8162-4f64-8cd5-4abe92509e19",
                         "name": "met_mast_data",
                         "tags": {},
                         "labels": [],
                         "files": []
                     },
-                    {
+                    "met_mast_data": {
                         "id": "7ead7669-8162-4f64-8cd5-4abe92509e18",
                         "name": "met_mast_data",
                         "tags": {},
                         "labels": [],
                         "files": []
                     }
-                ]
+                }
             }
         """
 
         twine = Twine(source=self.TWINE_WITH_INPUT_MANIFEST_WITH_TAG_TEMPLATE)
 
-        with self.assertRaises(exceptions.DatasetNameIsNotUnique):
+        with self.assertRaises(KeyError):
             twine.validate_input_manifest(source=input_manifest)
 
 

--- a/tests/test_manifest_strands.py
+++ b/tests/test_manifest_strands.py
@@ -589,8 +589,10 @@ class TestManifestStrands(BaseTestCase):
         with self.assertRaises(KeyError):
             twine.validate_input_manifest(source=input_manifest)
 
-    def test_error_raised_if_datasets_not_given_as_dictionary(self):
-        """Test that an error is raised if datasets are not given as a dictionary."""
+    def test_deprecation_warning_issued_and_datasets_format_translated_if_datasets_given_as_list(self):
+        """Test that, if datasets are given as a list (the old format), a deprecation warning is issued and the list
+        is translated to a dictionary (the new format).
+        """
         input_manifest = """
             {
                 "id": "8ead7669-8162-4f64-8cd5-4abe92509e17",
@@ -608,5 +610,18 @@ class TestManifestStrands(BaseTestCase):
 
         twine = Twine(source=self.TWINE_WITH_INPUT_MANIFEST_WITH_TAG_TEMPLATE)
 
-        with self.assertRaises(exceptions.InvalidManifestContents):
-            twine.validate_input_manifest(source=input_manifest)
+        with self.assertWarns(DeprecationWarning):
+            manifest = twine.validate_input_manifest(source=input_manifest)
+
+        self.assertEqual(
+            manifest["datasets"],
+            {
+                "met_mast_data": {
+                    "id": "7ead7669-8162-4f64-8cd5-4abe92509e19",
+                    "name": "met_mast_data",
+                    "tags": {},
+                    "labels": [],
+                    "files": [],
+                }
+            },
+        )

--- a/tests/test_twine.py
+++ b/tests/test_twine.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 
 from twined import Twine, exceptions
 from .base import BaseTestCase
@@ -63,6 +62,25 @@ class TestTwine(BaseTestCase):
         with self.assertRaises(exceptions.InvalidTwineJson):
             Twine(source=invalid_json_twine)
 
+    def test_error_raised_if_datasets_not_given_as_dictionary_in_manifest_strands(self):
+        """Test that an error is raised if datasets are not given as a dictionary in the manifest strands."""
+        for manifest_strand in ("configuration_manifest", "input_manifest", "output_manifest"):
+            with self.subTest(manifest_strand=manifest_strand):
+                invalid_twine = (
+                    """
+                {
+                    "%s": {
+                        "datasets": [
+                            {
+                                "key": "met_mast_data",
+                                "purpose": "A dataset containing meteorological mast data"
+                            }
+                        ]
+                    }
+                }
+                """
+                    % manifest_strand
+                )
 
-if __name__ == "__main__":
-    unittest.main()
+                with self.assertRaises(exceptions.InvalidTwineContents):
+                    Twine(source=invalid_twine)

--- a/tests/test_twine.py
+++ b/tests/test_twine.py
@@ -62,7 +62,7 @@ class TestTwine(BaseTestCase):
         with self.assertRaises(exceptions.InvalidTwineJson):
             Twine(source=invalid_json_twine)
 
-    def test_error_raised_if_datasets_not_given_as_dictionary_in_manifest_strands(self):
+    def test_deprecation_warning_issued_if_datasets_not_given_as_dictionary_in_manifest_strands(self):
         """Test that, if datasets are given as a list in the manifest strands, a deprecation warning is issued and the
         list (the old form) is converted to a dictionary (the new form).
         """

--- a/tests/test_twine.py
+++ b/tests/test_twine.py
@@ -1,6 +1,6 @@
 import os
 
-from twined import Twine, exceptions
+from twined import MANIFEST_STRANDS, Twine, exceptions
 from .base import BaseTestCase
 
 
@@ -63,8 +63,10 @@ class TestTwine(BaseTestCase):
             Twine(source=invalid_json_twine)
 
     def test_error_raised_if_datasets_not_given_as_dictionary_in_manifest_strands(self):
-        """Test that an error is raised if datasets are not given as a dictionary in the manifest strands."""
-        for manifest_strand in ("configuration_manifest", "input_manifest", "output_manifest"):
+        """Test that, if datasets are given as a list in the manifest strands, a deprecation warning is issued and the
+        list (the old form) is converted to a dictionary (the new form).
+        """
+        for manifest_strand in MANIFEST_STRANDS:
             with self.subTest(manifest_strand=manifest_strand):
                 invalid_twine = (
                     """
@@ -82,5 +84,15 @@ class TestTwine(BaseTestCase):
                     % manifest_strand
                 )
 
-                with self.assertRaises(exceptions.InvalidTwineContents):
-                    Twine(source=invalid_twine)
+                with self.assertWarns(DeprecationWarning):
+                    twine = Twine(source=invalid_twine)
+
+                self.assertEqual(
+                    getattr(twine, manifest_strand)["datasets"],
+                    {
+                        "met_mast_data": {
+                            "key": "met_mast_data",
+                            "purpose": "A dataset containing meteorological mast data",
+                        }
+                    },
+                )

--- a/twined/exceptions.py
+++ b/twined/exceptions.py
@@ -124,10 +124,6 @@ class InvalidManifestContents(InvalidManifest, ValidationError):
     """Raised when the manifest files are missing or do not match tags, sequences, clusters, extensions etc as required"""
 
 
-class DatasetNameIsNotUnique(InvalidManifest):
-    """Raise when a dataset's name is not unique within its manifest."""
-
-
 # --------------------- Exceptions relating to access of data using the Twine instance ------------------------
 
 # TODO This is related to filtering files from a manifest. Determine whether this belongs here,

--- a/twined/schema/manifest_schema.json
+++ b/twined/schema/manifest_schema.json
@@ -21,62 +21,81 @@
       "type": "string"
     },
     "datasets": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "description": "ID of the dataset, typically a uuid",
-            "type": "string"
-          },
-          "name": {
-            "description": "Name of the dataset",
-            "type": "string"
-          },
-          "tags": {"$ref": "#/$defs/tags"},
-          "labels": {"$ref": "#/$defs/labels"},
-          "files": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "description": "A file id",
-                  "type": "string"
+      "type": "object",
+      "patternProperties": {
+        ".+": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "description": "ID of the dataset, typically a uuid",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the dataset",
+              "type": "string"
+            },
+            "tags": {
+              "$ref": "#/$defs/tags"
+            },
+            "labels": {
+              "$ref": "#/$defs/labels"
+            },
+            "files": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "description": "A file id",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "Path at which the file can be found",
+                    "type": "string"
+                  },
+                  "extension": {
+                    "description": "The file extension (not including a '.')",
+                    "type": "string"
+                  },
+                  "sequence": {
+                    "description": "The ordering on the file, if any, within its group/cluster",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "cluster": {
+                    "description": "The group, or cluster, to which the file belongs",
+                    "type": "integer"
+                  },
+                  "posix_timestamp": {
+                    "description": "A posix based timestamp associated with the file. This may, but need not be, the created or modified time. ",
+                    "type": "number"
+                  },
+                  "tags": {
+                    "$ref": "#/$defs/tags"
+                  },
+                  "labels": {
+                    "$ref": "#/$defs/labels"
+                  }
                 },
-                "path": {
-                  "description": "Path at which the file can be found",
-                  "type": "string"
-                },
-                "extension": {
-                  "description": "The file extension (not including a '.')",
-                  "type": "string"
-                },
-                "sequence": {
-                  "description": "The ordering on the file, if any, within its group/cluster",
-                  "type": ["integer", "null"]
-                },
-                "cluster": {
-                  "description": "The group, or cluster, to which the file belongs",
-                  "type": "integer"
-                },
-                "posix_timestamp": {
-                  "description": "A posix based timestamp associated with the file. This may, but need not be, the created or modified time. ",
-                  "type": "number"
-                },
-                "tags": {"$ref": "#/$defs/tags"},
-                "labels": {"$ref": "#/$defs/labels"}
-              },
-              "required": [
-                "id",
-                "path",
-                "tags",
-                "labels"
-              ]
+                "required": [
+                  "id",
+                  "path",
+                  "tags",
+                  "labels"
+                ]
+              }
             }
-          }
-        },
-        "required": ["id", "name", "tags", "labels", "files"]
+          },
+          "required": [
+            "id",
+            "name",
+            "tags",
+            "labels",
+            "files"
+          ]
+        }
       }
     }
   },

--- a/twined/schema/manifest_schema.json
+++ b/twined/schema/manifest_schema.json
@@ -31,7 +31,7 @@
               "type": "string"
             },
             "name": {
-              "description": "Name of the dataset",
+              "description": "Name of the dataset (the same as its key in the 'datasets' field).",
               "type": "string"
             },
             "tags": {

--- a/twined/schema/twine_schema.json
+++ b/twined/schema/twine_schema.json
@@ -42,7 +42,7 @@
           "description": "A list of entries, each describing a dataset that should be attached to / made available to the digital twin",
           "patternProperties": {
             ".+": {
-              "description": "A dataset description mapped to a textual key uniquely identifying the dataset within the application/twin",
+              "description": "A dataset representation whose property name/key uniquely identifies the dataset to the service",
               "type": "object",
               "properties": {
                 "purpose": {

--- a/twined/schema/twine_schema.json
+++ b/twined/schema/twine_schema.json
@@ -38,27 +38,23 @@
       "type": "object",
       "properties": {
         "datasets": {
-          "type": "array",
+          "type": "object",
           "description": "A list of entries, each describing a dataset that should be attached to / made available to the digital twin",
-          "items": {
-            "type": "object",
-            "properties": {
-              "key": {
-                "description": "A textual key identifying this dataset within the application/twin",
-                "type": "string"
-              },
-              "purpose": {
-                "description": "What data this dataset contains, eg 'the set of data files from the energy production calculation process'",
-                "type": "string",
-                "default": ""
-              },
-              "file_tags_template": {
-                "$ref": "#/$defs/file_tags_template"
+          "patternProperties": {
+            ".+": {
+              "description": "A dataset description mapped to a textual key uniquely identifying the dataset within the application/twin",
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "description": "What data this dataset contains, eg 'the set of data files from the energy production calculation process'",
+                  "type": "string",
+                  "default": ""
+                },
+                "file_tags_template": {
+                  "$ref": "#/$defs/file_tags_template"
+                }
               }
-            },
-            "required": [
-              "key"
-            ]
+            }
           }
         }
       },

--- a/twined/twine.py
+++ b/twined/twine.py
@@ -190,18 +190,10 @@ class Twine:
         manifest_schema = getattr(self, manifest_kind)
 
         for dataset_schema in manifest_schema["datasets"]:
-            datasets = [dataset for dataset in manifest["datasets"] if dataset["name"] == dataset_schema["key"]]
+            dataset = manifest["datasets"].get(dataset_schema["key"])
 
-            if not datasets:
+            if not dataset:
                 continue
-
-            if len(datasets) > 1:
-                raise exceptions.DatasetNameIsNotUnique(
-                    f"There is more than one dataset named {dataset_schema['key']!r} - ensure each dataset within a "
-                    f"manifest is uniquely named."
-                )
-
-            dataset = datasets.pop(0)
 
             file_tags_template = dataset_schema.get("file_tags_template")
 

--- a/twined/twine.py
+++ b/twined/twine.py
@@ -189,8 +189,8 @@ class Twine:
         # This is the manifest schema included in the twine.json file, not the schema for manifest.json files.
         manifest_schema = getattr(self, manifest_kind)
 
-        for dataset_schema in manifest_schema["datasets"]:
-            dataset = manifest["datasets"].get(dataset_schema["key"])
+        for dataset_name, dataset_schema in manifest_schema["datasets"].items():
+            dataset = manifest["datasets"].get(dataset_name)
 
             if not dataset:
                 continue

--- a/twined/twine.py
+++ b/twined/twine.py
@@ -1,6 +1,7 @@
 import json as jsonlib
 import logging
 import os
+import warnings
 import pkg_resources
 from dotenv import load_dotenv
 from jsonschema import ValidationError, validate as jsonschema_validate
@@ -168,6 +169,16 @@ class Twine:
         if hasattr(data, "to_primitive"):
             inbound = False
             data = data.to_primitive()
+
+        if isinstance(data["datasets"], list):
+            data["datasets"] = {dataset["name"]: dataset for dataset in data["datasets"]}
+            warnings.warn(
+                message=(
+                    "Datasets belonging to a manifest should be provided as a dictionary mapping their name to"
+                    "themselves. Support for providing a list of datasets will be phased out soon."
+                ),
+                category=DeprecationWarning,
+            )
 
         self._validate_against_schema(kind, data)
         self._validate_dataset_file_tags(manifest_kind=kind, manifest=data)

--- a/twined/twine.py
+++ b/twined/twine.py
@@ -165,9 +165,9 @@ class Twine:
 
         # TODO elegant way of cleaning up this nasty serialisation hack to manage conversion of outbound manifests to primitive
         inbound = True
-        if hasattr(data, "serialise"):
+        if hasattr(data, "to_primitive"):
             inbound = False
-            data = data.serialise()
+            data = data.to_primitive()
 
         self._validate_against_schema(kind, data)
         self._validate_dataset_file_tags(manifest_kind=kind, manifest=data)

--- a/twined/utils/load_json.py
+++ b/twined/utils/load_json.py
@@ -33,7 +33,7 @@ def load_json(source, *args, **kwargs):
     if isinstance(source, io.IOBase):
         logger.debug("Detected source is a file-like object, loading contents...")
         check("file-like")
-        return json.load(source, *args, **kwargs)
+        return json.load(source, object_pairs_hook=raise_error_if_duplicate_keys, *args, **kwargs)
 
     elif not isinstance(source, str):
         logger.debug("Source is not a string, bypassing (returning raw data)")
@@ -44,9 +44,27 @@ def load_json(source, *args, **kwargs):
         logger.debug("Detected source is name of a *.json file, loading from %s", source)
         check("filename")
         with open(source) as f:
-            return json.load(f, *args, **kwargs)
+            return json.load(f, object_pairs_hook=raise_error_if_duplicate_keys, *args, **kwargs)
 
     else:
         logger.debug("Detected source is string containing json data, parsing...")
         check("string")
-        return json.loads(source, *args, **kwargs)
+        return json.loads(source, object_pairs_hook=raise_error_if_duplicate_keys, *args, **kwargs)
+
+
+def raise_error_if_duplicate_keys(pairs):
+    """Raise an error if any of the given key-value pairs have the same key.
+
+    :param list(tuple) pairs: a JSON object converted to a list of key-value pairs
+    :raise KeyError: if any of the pairs have the same key
+    :return dict:
+    """
+    result = {}
+
+    for key, value in pairs:
+        if key in result:
+            raise KeyError(f"Duplicate key detected: {key!r}.")
+
+        result[key] = value
+
+    return result


### PR DESCRIPTION
## Summary
Simplify specification of datasets in twines and manifests.

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#95](https://github.com/octue/twined/pull/95))
**IMPORTANT:** There are 2 breaking changes.

### Enhancements
- **BREAKING CHANGE:** Require "datasets" field to be a dictionary in `manifest.json` files
- **BREAKING CHANGE:** Require "datasets" field in the "manifest" strands of `twine.json` to be a dictionary
- Raise error if JSON objects contain duplicate keys

### Fixes
- Use correct method to transform manifests during validation
<!--- END AUTOGENERATED NOTES --->