### PR TITLE
Remove credentials environment variable name from children schema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("LICENSE") as f:
 
 setup(
     name="twined",
-    version="0.2.0",
+    version="0.2.1",
     py_modules=[],
     install_requires=["jsonschema ~= 3.2.0", "python-dotenv"],
     url="https://www.github.com/octue/twined",

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -60,8 +60,7 @@ class TestChildrenValidation(BaseTestCase):
                 "id": "some-id",
                 "backend": {
                     "name": "GCPPubSubBackend",
-                    "project_name": "my-project",
-                    "credentials_environment_variable": "GCP_SERVICE_ACCOUNT"
+                    "project_name": "my-project"
                 }
             }
         ]
@@ -88,13 +87,6 @@ class TestChildrenValidation(BaseTestCase):
         with self.assertRaises(exceptions.InvalidValuesContents):
             Twine().validate_children(source=single_child_missing_backend)
 
-    def test_backend_credentials_environment_variable_can_be_empty(self):
-        """Test that the backend credentials environment variable of a child can be empty."""
-        children = (
-            """[{"key": "gis", "id": "some-id", "backend": {"name": "GCPPubSubBackend", "project_name": "blah"}}]"""
-        )
-        Twine(source=self.VALID_TWINE_WITH_CHILDREN).validate_children(source=children)
-
     def test_extra_key_validation_on_empty_twine(self):
         """Test that children with extra data will not raise a validation error on an empty twine."""
         children_values_with_extra_data = """
@@ -118,8 +110,7 @@ class TestChildrenValidation(BaseTestCase):
                     "id": "some-id",
                     "backend": {
                         "name": "GCPPubSubBackend",
-                        "project_name": "my-project",
-                        "credentials_environment_variable": "GCP_SERVICE_ACCOUNT"
+                        "project_name": "my-project"
                     },
                     "some_extra_property": "should not be a problem if present"
                 }

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -72,12 +72,12 @@ class TestChildrenValidation(BaseTestCase):
         Twine().validate_children(source=[])
 
     def test_missing_children(self):
-        """Test that a twine with children will not validate on an empty children input"""
+        """Test that a twine with children will not validate on an empty children input."""
         with self.assertRaises(exceptions.InvalidValuesContents):
             Twine(source=self.VALID_TWINE_WITH_CHILDREN).validate_children(source=[])
 
     def test_extra_children(self):
-        """Test that a twine with no children will not validate a non-empty children input"""
+        """Test that a twine with no children will not validate a non-empty children input."""
         with self.assertRaises(exceptions.InvalidValuesContents):
             Twine().validate_children(source=self.VALID_CHILD_VALUE)
 
@@ -87,6 +87,13 @@ class TestChildrenValidation(BaseTestCase):
 
         with self.assertRaises(exceptions.InvalidValuesContents):
             Twine().validate_children(source=single_child_missing_backend)
+
+    def test_backend_credentials_environment_variable_can_be_empty(self):
+        """Test that the backend credentials environment variable of a child can be empty."""
+        children = (
+            """[{"key": "gis", "id": "some-id", "backend": {"name": "GCPPubSubBackend", "project_name": "blah"}}]"""
+        )
+        Twine(source=self.VALID_TWINE_WITH_CHILDREN).validate_children(source=children)
 
     def test_extra_key_validation_on_empty_twine(self):
         """Test that children with extra data will not raise a validation error on an empty twine."""

--- a/twined/schema/children_schema.json
+++ b/twined/schema/children_schema.json
@@ -33,7 +33,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["name", "project_name", "credentials_environment_variable"]
+                        "required": ["name", "project_name"]
                     }
                 ]
             }

--- a/twined/schema/children_schema.json
+++ b/twined/schema/children_schema.json
@@ -27,10 +27,6 @@
                             "project_name": {
                                 "description": "Name of the Google Cloud Platform (GCP) project the child exists in.",
                                 "type": "string"
-                            },
-                            "credentials_environment_variable": {
-                                "description": "Name of environment variable containing either the absolute path to a Google Cloud Platform credentials JSON file or the JSON itself as a string.",
-                                "type": "string"
                             }
                         },
                         "required": ["name", "project_name"]

--- a/twined/twine.py
+++ b/twined/twine.py
@@ -187,7 +187,7 @@ class Twine:
             data["datasets"] = {dataset["name"]: dataset for dataset in data["datasets"]}
             warnings.warn(
                 message=(
-                    "Datasets belonging to a manifest should be provided as a dictionary mapping their name to"
+                    "Datasets belonging to a manifest should be provided as a dictionary mapping their name to "
                     "themselves. Support for providing a list of datasets will be phased out soon."
                 ),
                 category=DeprecationWarning,


### PR DESCRIPTION
## Summary
Remove the credentials environment variable name from the children schema. The default `GOOGLE_APPLICATION_CREDENTIALS` is the only name now used in `octue-sdk-python`.

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#98](https://github.com/octue/twined/pull/98))

### Enhancements
- Remove the credentials environment variable name from the children schema
<!--- END AUTOGENERATED NOTES --->