### PR TITLE
Use latest JSON metaschema

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -48,7 +48,7 @@ copied straight from the unit test cases, so you can always check there to see h
              "children": [
              ],
              "configuration_values_schema": {
-                 "$schema": "https://json-schema.org/draft/2019-09/schema",
+                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                  "title": "Foundation cost twin configuration",
                  "description": "Set config parameters and constants at startup of the twin.",
                  "type": "object",
@@ -68,7 +68,7 @@ copied straight from the unit test cases, so you can always check there to see h
                  }
              },
              "input_values_schema": {
-                 "$schema": "https://json-schema.org/draft/2019-09/schema",
+                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                  "title": "Input Values schema for the foundation cost twin",
                  "description": "These values are supplied to the twin asynchronously over a web socket. So as these values change, the twin can reply with an update.",
                  "type": "object",
@@ -135,7 +135,7 @@ copied straight from the unit test cases, so you can always check there to see h
                 ]
             },
          	"input_values_schema": {
-         		"$schema": "https://json-schema.org/draft/2019-09/schema",
+         		"$schema": "https://json-schema.org/draft/2020-12/schema",
          		"title": "Input Values for the weather service twin",
          		"description": "This is a simple example for getting metocean conditions at a single location",
          		"type": "object",
@@ -174,7 +174,7 @@ copied straight from the unit test cases, so you can always check there to see h
                 ]
             },
          	"output_values_schema": {
-         		"$schema": "https://json-schema.org/draft/2019-09/schema",
+         		"$schema": "https://json-schema.org/draft/2020-12/schema",
          		"title": "Output Values for the metocean service twin",
          		"description": "The output values strand of an example twine",
          		"type": "object",

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -48,7 +48,7 @@ copied straight from the unit test cases, so you can always check there to see h
              "children": [
              ],
              "configuration_values_schema": {
-                 "$schema": "http://json-schema.org/2019-09/schema#",
+                 "$schema": "https://json-schema.org/draft/2019-09/schema",
                  "title": "Foundation cost twin configuration",
                  "description": "Set config parameters and constants at startup of the twin.",
                  "type": "object",
@@ -68,7 +68,7 @@ copied straight from the unit test cases, so you can always check there to see h
                  }
              },
              "input_values_schema": {
-                 "$schema": "http://json-schema.org/2019-09/schema#",
+                 "$schema": "https://json-schema.org/draft/2019-09/schema",
                  "title": "Input Values schema for the foundation cost twin",
                  "description": "These values are supplied to the twin asynchronously over a web socket. So as these values change, the twin can reply with an update.",
                  "type": "object",
@@ -135,7 +135,7 @@ copied straight from the unit test cases, so you can always check there to see h
                 ]
             },
          	"input_values_schema": {
-         		"$schema": "http://json-schema.org/2019-09/schema#",
+         		"$schema": "https://json-schema.org/draft/2019-09/schema",
          		"title": "Input Values for the weather service twin",
          		"description": "This is a simple example for getting metocean conditions at a single location",
          		"type": "object",
@@ -174,7 +174,7 @@ copied straight from the unit test cases, so you can always check there to see h
                 ]
             },
          	"output_values_schema": {
-         		"$schema": "http://json-schema.org/2019-09/schema#",
+         		"$schema": "https://json-schema.org/draft/2019-09/schema",
          		"title": "Output Values for the metocean service twin",
          		"description": "The output values strand of an example twine",
          		"type": "object",

--- a/docs/source/quick_start_create_your_first_twine.rst
+++ b/docs/source/quick_start_create_your_first_twine.rst
@@ -24,7 +24,7 @@ Now, let's define an input values strand, to specify what values are required by
         "title": "My first digital twin",
         "description": "A simple example to build on..."
         "input_values_schema": {
-            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "title": "Input Values schema for my first digital twin",
             "description": "These values are supplied to the twin by another program (often over a websocket, depending on your integration provider). So as these values change, the twin can reply with an update.",
             "type": "object",
@@ -50,7 +50,7 @@ Finally, let's define an output values strand, to define what kind of data is re
 .. code-block:: javascript
 
         "output_values_schema": {
-            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "title": "Output Values schema for my first digital twin",
             "description": "The twin will output data that matches this schema",
             "type": "object",

--- a/docs/source/quick_start_create_your_first_twine.rst
+++ b/docs/source/quick_start_create_your_first_twine.rst
@@ -24,7 +24,7 @@ Now, let's define an input values strand, to specify what values are required by
         "title": "My first digital twin",
         "description": "A simple example to build on..."
         "input_values_schema": {
-            "$schema": "http://json-schema.org/2019-09/schema#",
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "title": "Input Values schema for my first digital twin",
             "description": "These values are supplied to the twin by another program (often over a websocket, depending on your integration provider). So as these values change, the twin can reply with an update.",
             "type": "object",
@@ -50,7 +50,7 @@ Finally, let's define an output values strand, to define what kind of data is re
 .. code-block:: javascript
 
         "output_values_schema": {
-            "$schema": "http://json-schema.org/2019-09/schema#",
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "title": "Output Values schema for my first digital twin",
             "description": "The twin will output data that matches this schema",
             "type": "object",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("LICENSE") as f:
 
 setup(
     name="twined",
-    version="0.2.1",
+    version="0.2.2",
     py_modules=[],
     install_requires=["jsonschema ~= 3.2.0", "python-dotenv"],
     url="https://www.github.com/octue/twined",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     name="twined",
     version="0.2.2",
     py_modules=[],
-    install_requires=["jsonschema ~= 3.2.0", "python-dotenv"],
+    install_requires=["jsonschema ~= 4.4.0", "python-dotenv"],
     url="https://www.github.com/octue/twined",
     license="MIT",
     author="Octue (github: octue)",

--- a/tests/base.py
+++ b/tests/base.py
@@ -6,7 +6,7 @@ import unittest
 VALID_SCHEMA_TWINE = """
     {
         "configuration_values_schema": {
-            "$schema": "http://json-schema.org/2019-09/schema#",
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "title": "The example configuration form",
             "description": "The configuration strand of an example twine",
             "type": "object",
@@ -21,7 +21,7 @@ VALID_SCHEMA_TWINE = """
             }
         },
         "input_values_schema": {
-            "$schema": "http://json-schema.org/2019-09/schema#",
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
             "title": "Input Values",
             "description": "The input values strand of an example twine, with a required height value",
             "type": "object",

--- a/tests/base.py
+++ b/tests/base.py
@@ -6,7 +6,7 @@ import unittest
 VALID_SCHEMA_TWINE = """
     {
         "configuration_values_schema": {
-            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "title": "The example configuration form",
             "description": "The configuration strand of an example twine",
             "type": "object",
@@ -21,7 +21,7 @@ VALID_SCHEMA_TWINE = """
             }
         },
         "input_values_schema": {
-            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "title": "Input Values",
             "description": "The input values strand of an example twine, with a required height value",
             "type": "object",

--- a/tests/data/apps/empty_app/twine.json
+++ b/tests/data/apps/empty_app/twine.json
@@ -2,7 +2,7 @@
 	"children": [
 	],
 	"configuration_values_schema": {
-		"$schema": "https://json-schema.org/draft/2019-09/schema",
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
 		"title": "The example configuration form",
 		"description": "The configuration strand of an example twine",
 		"type": "object",
@@ -15,7 +15,7 @@
 		"datasets": {}
 	},
 	"input_values_schema": {
-		"$schema": "https://json-schema.org/draft/2019-09/schema",
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
 		"title": "Input Values",
 		"description": "The input values strand of an example twine",
 		"type": "object",

--- a/tests/data/apps/empty_app/twine.json
+++ b/tests/data/apps/empty_app/twine.json
@@ -2,7 +2,7 @@
 	"children": [
 	],
 	"configuration_values_schema": {
-		"$schema": "http://json-schema.org/2019-09/schema#",
+		"$schema": "https://json-schema.org/draft/2019-09/schema",
 		"title": "The example configuration form",
 		"description": "The configuration strand of an example twine",
 		"type": "object",
@@ -15,7 +15,7 @@
 		"datasets": {}
 	},
 	"input_values_schema": {
-		"$schema": "http://json-schema.org/2019-09/schema#",
+		"$schema": "https://json-schema.org/draft/2019-09/schema",
 		"title": "Input Values",
 		"description": "The input values strand of an example twine",
 		"type": "object",

--- a/tests/data/apps/example_app/twine.json
+++ b/tests/data/apps/example_app/twine.json
@@ -7,7 +7,7 @@
 		}
 	],
 	"configuration_values_schema": {
-		"$schema": "http://json-schema.org/2019-09/schema#",
+		"$schema": "https://json-schema.org/draft/2019-09/schema",
 		"title": "The example configuration form",
 		"description": "The configuration strand of an example twine",
 		"type": "object",
@@ -42,7 +42,7 @@
 		}
 	},
 	"input_values_schema": {
-		"$schema": "http://json-schema.org/2019-09/schema#",
+		"$schema": "https://json-schema.org/draft/2019-09/schema",
 		"title": "Input Values",
 		"description": "The input values strand of an example twine",
 		"type": "object",

--- a/tests/data/apps/example_app/twine.json
+++ b/tests/data/apps/example_app/twine.json
@@ -7,7 +7,7 @@
 		}
 	],
 	"configuration_values_schema": {
-		"$schema": "https://json-schema.org/draft/2019-09/schema",
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
 		"title": "The example configuration form",
 		"description": "The configuration strand of an example twine",
 		"type": "object",
@@ -42,7 +42,7 @@
 		}
 	},
 	"input_values_schema": {
-		"$schema": "https://json-schema.org/draft/2019-09/schema",
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
 		"title": "Input Values",
 		"description": "The input values strand of an example twine",
 		"type": "object",

--- a/tests/data/apps/simple_app/twine.json
+++ b/tests/data/apps/simple_app/twine.json
@@ -1,6 +1,6 @@
 {
 	"configuration_values_schema": {
-		"$schema": "http://json-schema.org/2019-09/schema#",
+		"$schema": "https://json-schema.org/draft/2019-09/schema",
 		"title": "Configuration for a simple app",
 		"description": "The app creates a mandelbrot plot",
 		"type": "object",

--- a/tests/data/apps/simple_app/twine.json
+++ b/tests/data/apps/simple_app/twine.json
@@ -1,6 +1,6 @@
 {
 	"configuration_values_schema": {
-		"$schema": "https://json-schema.org/draft/2019-09/schema",
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
 		"title": "Configuration for a simple app",
 		"description": "The app creates a mandelbrot plot",
 		"type": "object",

--- a/tests/test_schema_strands.py
+++ b/tests/test_schema_strands.py
@@ -50,7 +50,7 @@ class TestSchemaStrands(BaseTestCase):
         valid_no_output_schema_twine = """
            {
                 "configuration_values_schema": {
-                    "$schema": "https://json-schema.org/draft/2019-09/schema",
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
                     "title": "The example configuration form",
                     "description": "The configuration strand of an example twine",
                     "type": "object",

--- a/tests/test_schema_strands.py
+++ b/tests/test_schema_strands.py
@@ -50,7 +50,7 @@ class TestSchemaStrands(BaseTestCase):
         valid_no_output_schema_twine = """
            {
                 "configuration_values_schema": {
-                    "$schema": "http://json-schema.org/2019-09/schema#",
+                    "$schema": "https://json-schema.org/draft/2019-09/schema",
                     "title": "The example configuration form",
                     "description": "The configuration strand of an example twine",
                     "type": "object",

--- a/tests/test_twine.py
+++ b/tests/test_twine.py
@@ -49,7 +49,7 @@ class TestTwine(BaseTestCase):
             {
                 "children": [
                 "configuration_values_schema": {
-                    "$schema": "http://json-schema.org/2019-09/schema#",
+                    "$schema": "https://json-schema.org/draft/2019-09/schema",
                     "title": "The example configuration form",
                     "description": "The configuration strand of an example twine",
                     "type": "object",

--- a/tests/test_twine.py
+++ b/tests/test_twine.py
@@ -49,7 +49,7 @@ class TestTwine(BaseTestCase):
             {
                 "children": [
                 "configuration_values_schema": {
-                    "$schema": "https://json-schema.org/draft/2019-09/schema",
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
                     "title": "The example configuration form",
                     "description": "The configuration strand of an example twine",
                     "type": "object",

--- a/twined/schema/manifest_schema.json
+++ b/twined/schema/manifest_schema.json
@@ -7,11 +7,9 @@
     "labels": {
       "description": "Textual labels associated with the object",
       "type": "array",
-      "items": [
-        {
-          "type": "string"
-        }
-      ]
+      "items": {
+        "type": "string"
+      }
     }
   },
   "type": "object",

--- a/twined/schema/twine_schema.json
+++ b/twined/schema/twine_schema.json
@@ -62,7 +62,7 @@
     }
   },
   "type": "object",
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "properties": {
     "children": {
       "type": "array",

--- a/twined/schema/twine_schema.json
+++ b/twined/schema/twine_schema.json
@@ -62,7 +62,7 @@
     }
   },
   "type": "object",
-  "$schema": "http://json-schema.org/2019-09/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "properties": {
     "children": {
       "type": "array",


### PR DESCRIPTION
## Summary
Use the latest JSON metaschema and switch to HTTPS to access it.

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#100](https://github.com/octue/twined/pull/100))

### Enhancements
- Use latest JSON metaschema `2020-12` and access it via HTTPS

### Fixes
- Fix labels ref in manifest schema

### Dependencies
- Upgrade to `jsonschema==4.4.0` 

<!--- END AUTOGENERATED NOTES --->