### PR TITLE
Update manifest schema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("LICENSE") as f:
 
 setup(
     name="twined",
-    version="0.5.0",
+    version="0.5.1",
     py_modules=[],
     install_requires=["jsonschema ~= 4.4.0", "python-dotenv"],
     url="https://www.github.com/octue/twined",

--- a/tests/test_manifest_strands.py
+++ b/tests/test_manifest_strands.py
@@ -121,31 +121,17 @@ class TestManifestStrands(BaseTestCase):
                         "files": [
                             {
                                 "path": "configuration/datasets/7ead7669/file_1.csv",
-                                "cluster": 0,
-                                "sequence": 0,
-                                "extension": "csv",
                                 "tags": {},
                                 "labels": [],
-                                "posix_timestamp": 0,
-                                "id": "abff07bc-7c19-4ed5-be6d-a6546eae8e86",
-                                "last_modified": "2019-02-28T22:40:30.533005Z",
-                                "name": "file_1.csv",
-                                "size_bytes": 59684813,
-                                "sha-512/256": "somesha"
+                                "timestamp": 0,
+                                "id": "abff07bc-7c19-4ed5-be6d-a6546eae8e86"
                             },
                             {
                                 "path": "configuration/datasets/7ead7669/file_2.csv",
-                                "cluster": 0,
-                                "sequence": 1,
-                                "extension": "csv",
                                 "tags": {},
                                 "labels": [],
-                                "posix_timestamp": 0,
-                                "id": "bbff07bc-7c19-4ed5-be6d-a6546eae8e45",
-                                "last_modified": "2019-02-28T22:40:40.633001Z",
-                                "name": "file_2.csv",
-                                "size_bytes": 59684813,
-                                "sha-512/256": "someothersha"
+                                "timestamp": 0,
+                                "id": "bbff07bc-7c19-4ed5-be6d-a6546eae8e45"
                             }
                         ]
                     }
@@ -165,31 +151,17 @@ class TestManifestStrands(BaseTestCase):
                         "files": [
                             {
                                 "path": "input/datasets/7ead7669/file_1.csv",
-                                "cluster": 0,
-                                "sequence": 0,
-                                "extension": "csv",
                                 "tags": {},
                                 "labels": [],
-                                "posix_timestamp": 0,
-                                "id": "abff07bc-7c19-4ed5-be6d-a6546eae8e86",
-                                "last_modified": "2019-02-28T22:40:30.533005Z",
-                                "name": "file_1.csv",
-                                "size_bytes": 59684813,
-                                "sha-512/256": "somesha"
+                                "timestamp": 0,
+                                "id": "abff07bc-7c19-4ed5-be6d-a6546eae8e86"
                             },
                             {
                                 "path": "input/datasets/7ead7669/file_2.csv",
-                                "cluster": 0,
-                                "sequence": 1,
-                                "extension": "csv",
                                 "tags": {},
                                 "labels": [],
-                                "posix_timestamp": 0,
-                                "id": "bbff07bc-7c19-4ed5-be6d-a6546eae8e45",
-                                "last_modified": "2019-02-28T22:40:40.633001Z",
-                                "name": "file_2.csv",
-                                "size_bytes": 59684813,
-                                "sha-512/256": "someothersha"
+                                "timestamp": 0,
+                                "id": "bbff07bc-7c19-4ed5-be6d-a6546eae8e45"
                             }
                         ]
                     },
@@ -210,31 +182,17 @@ class TestManifestStrands(BaseTestCase):
                         "files": [
                             {
                                 "path": "input/datasets/7ead7669/file_1.csv",
-                                "cluster": 0,
-                                "sequence": 0,
-                                "extension": "csv",
                                 "tags": {},
                                 "labels": [],
-                                "posix_timestamp": 0,
-                                "id": "abff07bc-7c19-4ed5-be6d-a6546eae8e86",
-                                "last_modified": "2019-02-28T22:40:30.533005Z",
-                                "name": "file_1.csv",
-                                "size_bytes": 59684813,
-                                "sha-512/256": "somesha"
+                                "timestamp": 0,
+                                "id": "abff07bc-7c19-4ed5-be6d-a6546eae8e86"
                             },
                             {
                                 "path": "input/datasets/7ead7669/file_2.csv",
-                                "cluster": 0,
-                                "sequence": 1,
-                                "extension": "csv",
                                 "tags": {},
                                 "labels": [],
-                                "posix_timestamp": 0,
-                                "id": "bbff07bc-7c19-4ed5-be6d-a6546eae8e45",
-                                "last_modified": "2019-02-28T22:40:40.633001Z",
-                                "name": "file_2.csv",
-                                "size_bytes": 59684813,
-                                "sha-512/256": "someothersha"
+                                "timestamp": 0,
+                                "id": "bbff07bc-7c19-4ed5-be6d-a6546eae8e45"
                             }
                         ]
                     }

--- a/twined/schema/manifest_schema.json
+++ b/twined/schema/manifest_schema.json
@@ -46,47 +46,48 @@
                 "files": {
                   "type": "array",
                   "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "description": "A file id",
-                        "type": "string"
-                      },
-                      "path": {
-                        "description": "Path at which the file can be found",
-                        "type": "string"
-                      },
-                      "extension": {
-                        "description": "The file extension (not including a '.')",
-                        "type": "string"
-                      },
-                      "sequence": {
-                        "description": "The ordering on the file, if any, within its group/cluster",
-                        "type": [
-                          "integer",
-                          "null"
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "description": "A file id",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Path at which the file can be found",
+                            "type": "string"
+                          },
+                          "timestamp": {
+                            "oneOf": [
+                              {
+                                "description": "A posix based timestamp associated with the file. This may, but need not be, the created or modified time. ",
+                                "type": "number"
+                              },
+                              {
+                                "description": "A posix based timestamp associated with the file. This may, but need not be, the created or modified time. ",
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "tags": {
+                            "$ref": "#/$defs/tags"
+                          },
+                          "labels": {
+                            "$ref": "#/$defs/labels"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "path",
+                          "timestamp",
+                          "tags",
+                          "labels"
                         ]
                       },
-                      "cluster": {
-                        "description": "The group, or cluster, to which the file belongs",
-                        "type": "integer"
-                      },
-                      "posix_timestamp": {
-                        "description": "A posix based timestamp associated with the file. This may, but need not be, the created or modified time. ",
-                        "type": "number"
-                      },
-                      "tags": {
-                        "$ref": "#/$defs/tags"
-                      },
-                      "labels": {
-                        "$ref": "#/$defs/labels"
+                      {
+                        "type": "string"
                       }
-                    },
-                    "required": [
-                      "id",
-                      "path",
-                      "tags",
-                      "labels"
                     ]
                   }
                 }


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#108](https://github.com/octue/twined/pull/108))

### Fixes
- Update manifest schema to be compatible with `files` fields in serialised datasets and to remove outdated fields within serialised files

<!--- END AUTOGENERATED NOTES --->